### PR TITLE
Change E-Mail validator to "com.sanctionco.jmail:jmail" (issue https://github.com/networknt/openapi-parser/issues/64)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.light-4j>2.2.1-SNAPSHOT</version.light-4j>
         <version.jackson>2.18.1</version.jackson>
-        <version.javamail>1.6.2</version.javamail>
+        <version.jmail>1.6.3</version.jmail>
         <version.slf4j>2.0.16</version.slf4j>
         <version.logback>1.5.16</version.logback>
         <version.junit>4.13.2</version.junit>
@@ -134,9 +134,9 @@
             <version>${version.jackson}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.mail</groupId>
-            <artifactId>javax.mail</artifactId>
-            <version>${version.javamail}</version>
+            <groupId>com.sanctionco.jmail</groupId>
+            <artifactId>jmail</artifactId>
+            <version>${version.jmail}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/com/networknt/oas/validator/ValidatorBase.java
+++ b/src/main/java/com/networknt/oas/validator/ValidatorBase.java
@@ -13,9 +13,10 @@ package com.networknt.oas.validator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.*;
 import com.networknt.jsonoverlay.*;
+import com.sanctionco.jmail.EmailValidator;
+import com.sanctionco.jmail.FailureReason;
+import com.sanctionco.jmail.JMail;
 
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -161,12 +162,11 @@ public abstract class ValidatorBase<V> implements Validator<V> {
 
 	private void checkEmail(Overlay<String> overlay) {
 		String email = overlay.get();
-		try {
-			InternetAddress addr = new InternetAddress();
-			addr.setAddress(email);
-			addr.validate();
-		} catch (AddressException e) {
-			results.addError(msg(BadEmail, email, e.toString()), overlay);
+		EmailValidator validator = JMail.strictValidator();
+		FailureReason failureReason = validator.validate(email).getFailureReason();
+		if (!FailureReason.NONE.equals(failureReason)) {
+			results.addError(msg(BadEmail, email, failureReason.toString() + " [" + failureReason.ordinal() + "]"),
+					overlay);
 		}
 	}
 


### PR DESCRIPTION
Here's a first attempt to use "jmail" for validating E-Mail-Addresses in order to get rid of "javax" stuff which creates legal issues when kept around in Jakarta EE 9+ applications... 😢 

In case you wish advanced configurations of the validation, such as described here:

https://github.com/RohanNagar/jmail?tab=readme-ov-file#usage

just let me know, and I will refine the PR accordingly...

Many thanks for considering it this time... 👍 🤞 